### PR TITLE
ignore 0 resolution

### DIFF
--- a/src/main/scala/org/openeo/opensearch/OpenSearchResponses.scala
+++ b/src/main/scala/org/openeo/opensearch/OpenSearchResponses.scala
@@ -61,23 +61,17 @@ object OpenSearchResponses {
 
   }
 
-  private def isDuplicate(d1: Option[ZonedDateTime], d2: Option[ZonedDateTime]): Boolean = {
-    if (d1.isDefined != d2.isDefined) return false
-    if (d1.isDefined && d2.isDefined
-      && ChronoUnit.SECONDS.between(d1.get, d2.get) > 30) return false
-    true
-  }
-
   private def isDuplicate(f1: Feature, f2: Feature): Boolean = {
     if (ChronoUnit.SECONDS.between(f1.nominalDate, f2.nominalDate) > 30) return false
-
-    if (!isDuplicate(f1.generalProperties.published, f2.generalProperties.published)) return false
 
     // If orbitNumber or organisationName is None it works out too
     if (f1.generalProperties.orbitNumber != f2.generalProperties.orbitNumber) return false
     if (f1.generalProperties.instrument != f2.generalProperties.instrument) return false
     if (f1.generalProperties.organisationName != f2.generalProperties.organisationName) return false
-    if (f1.resolution != f2.resolution) return false
+    if (f1.resolution.isDefined && f2.resolution.isDefined
+      && f1.resolution.get != 0 && f2.resolution.get != 0) {
+      if (f1.resolution != f2.resolution) return false
+    }
 
     if (f1.geometry.isDefined && !f1.geometry.get.equalsExact(f2.geometry.get, 0.0001)) return false
     true

--- a/src/test/scala/org.openeo/OpenSearchClientTest.scala
+++ b/src/test/scala/org.openeo/OpenSearchClientTest.scala
@@ -53,6 +53,19 @@ class OpenSearchClientTest {
     assertTrue(aFeature.geometry.isDefined)
   }
 
+  @Test
+  def testIgnoreZeroResolution(): Unit = {
+    val openSearch = CreodiasClient()
+
+    val features = openSearch.getProducts(
+      collectionId = "Sentinel2",
+      (LocalDate.of(2018, 8, 12), LocalDate.of(2018, 8, 13)),
+      ProjectedExtent(Extent(-3.7937789378418247, 38.486414764328515, -3.5314443712734733, 38.69684729114566), LatLng),
+      Map[String, Any]("eo:cloud_cover" -> 90.0, "productType" -> "L2A"), correlationId = "hello", "S2MSI2A"
+    )
+    assertEquals(2, features.length)
+    assertEquals("/eodata/Sentinel-2/MSI/L2A/2018/08/12/S2A_MSIL2A_20180812T105621_N0213_R094_T30SVH_20201026T165913.SAFE", features.head.id)
+  }
 
   @Test
   def testCreoGetProductsDEM(): Unit = {


### PR DESCRIPTION
Ignore resolution difference when one product has resolution 0. Ignore published date differences when dedupping, latest published product will be selected anyway.

https://github.com/Open-EO/openeo-opensearch-client/issues/9