### PR TITLE
Allow parallel query

### DIFF
--- a/src/main/scala/org/openeo/opensearch/OpenSearchClient.scala
+++ b/src/main/scala/org/openeo/opensearch/OpenSearchClient.scala
@@ -23,7 +23,7 @@ object OpenSearchClient {
   private val logger = LoggerFactory.getLogger(classOf[OpenSearchClient])
   private val requestCounter = new AtomicLong
 
-  def apply(endpoint: URL, isUTM: Boolean = false, clientType: String = ""):OpenSearchClient = {
+  def apply(endpoint: URL, isUTM: Boolean = false, clientType: String = "", allowParallelQuery: Boolean = false): OpenSearchClient = {
     if (clientType != "") {
       clientType.toLowerCase() match {
         case "stac" => new STACClient(endpoint, false)
@@ -36,7 +36,7 @@ object OpenSearchClient {
       // Guess Catalog Type using URL.
       endpoint.toString match {
         case s if s.contains("creo") => new CreodiasClient(endpoint)
-        case s if s.contains("catalogue.dataspace.copernicus.eu/resto") => new CreodiasClient(endpoint)
+        case s if s.contains("catalogue.dataspace.copernicus.eu/resto") => new CreodiasClient(endpoint, allowParallelQuery)
         case s if s.contains("aws") => new STACClient(endpoint)
         case s if s.contains("c-scale") => new STACClient(endpoint, false)
         case _ => new OscarsClient(endpoint, isUTM)
@@ -65,13 +65,13 @@ object OpenSearchClient {
    *  @return An OpenSearchClient.
    *  @throws IllegalArgumentException if the catalogType is unknown.
    */
-  def apply(endpoint: String, isUTM: Boolean, dateRegex: String, bands: util.List[String], clientType: String): OpenSearchClient = {
+  def apply(endpoint: String, isUTM: Boolean, dateRegex: String, bands: util.List[String], clientType: String, allowParallelQuery: Boolean): OpenSearchClient = {
     clientType match {
       case "cgls_oscars" => new CGLSOscarsClient(new URL(endpoint), bands)
       case "cgls" => new GlobalNetCDFSearchClient(endpoint, bands, dateRegex.r.unanchored)
       case "agera5" => new Agera5SearchClient(endpoint, bands, dateRegex.r.unanchored)
       case "globspatialonly" => new GeotiffNoDateSearchClient(endpoint, bands)
-      case _ => apply(new URL(endpoint), isUTM, clientType)
+      case _ => apply(new URL(endpoint), isUTM, clientType, allowParallelQuery)
     }
   }
 }

--- a/src/main/scala/org/openeo/opensearch/OpenSearchClient.scala
+++ b/src/main/scala/org/openeo/opensearch/OpenSearchClient.scala
@@ -74,6 +74,10 @@ object OpenSearchClient {
       case _ => apply(new URL(endpoint), isUTM, clientType, allowParallelQuery)
     }
   }
+
+  def apply(endpoint: String, isUTM: Boolean, dateRegex: String, bands: util.List[String], clientType: String): OpenSearchClient = {
+    apply(endpoint, isUTM, dateRegex, bands, clientType, allowParallelQuery = false)
+  }
 }
 
 abstract class OpenSearchClient {

--- a/src/main/scala/org/openeo/opensearch/backends/CreodiasClient.scala
+++ b/src/main/scala/org/openeo/opensearch/backends/CreodiasClient.scala
@@ -33,7 +33,8 @@ object CreodiasClient{
   }
 }
 
-class CreodiasClient(val endpoint: URL = new URL("https://catalogue.dataspace.copernicus.eu/resto")) extends OpenSearchClient {
+class CreodiasClient(val endpoint: URL = new URL("https://catalogue.dataspace.copernicus.eu/resto"),
+                     allowParallelQuery: Boolean = false) extends OpenSearchClient {
   import CreodiasClient._
 
   require(endpoint != null)
@@ -45,9 +46,7 @@ class CreodiasClient(val endpoint: URL = new URL("https://catalogue.dataspace.co
                            bbox: ProjectedExtent,
                            attributeValues: Map[String, Any], correlationId: String,
                            processingLevel: String): Seq[Feature] = {
-    if (this.endpoint.toString.contains("catalogue.dataspace.copernicus.eu/resto")
-      && collectionId == "Sentinel2"
-      && dateRange.isDefined) {
+    if (allowParallelQuery && dateRange.isDefined) {
       // DEM has a big difference between beginDate and completionDate.
       // The temporal extent should span both dates, so we avoid doing this for DEM.
       // For Sentinel2, beginDate and completionDate look alike so this is no issue here.

--- a/src/main/scala/org/openeo/opensearch/backends/CreodiasClient.scala
+++ b/src/main/scala/org/openeo/opensearch/backends/CreodiasClient.scala
@@ -34,7 +34,7 @@ object CreodiasClient{
 }
 
 class CreodiasClient(val endpoint: URL = new URL("https://catalogue.dataspace.copernicus.eu/resto"),
-                     allowParallelQuery: Boolean = false) extends OpenSearchClient {
+                     val allowParallelQuery: Boolean = false) extends OpenSearchClient {
   import CreodiasClient._
 
   require(endpoint != null)
@@ -202,12 +202,12 @@ class CreodiasClient(val endpoint: URL = new URL("https://catalogue.dataspace.co
 
 
   override final def equals(other: Any): Boolean = other match {
-    case that: CreodiasClient => this.endpoint == that.endpoint
+    case that: CreodiasClient => this.endpoint == that.endpoint && this.allowParallelQuery == that.allowParallelQuery
     case _ => false
   }
 
   override final def hashCode(): Int = {
-    val state = Seq(endpoint)
+    val state = Seq(endpoint, allowParallelQuery)
     state.map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)
   }
 }

--- a/src/test/scala/org/openeo/opensearch/backends/OscarsClientTest.scala
+++ b/src/test/scala/org/openeo/opensearch/backends/OscarsClientTest.scala
@@ -22,7 +22,7 @@ class OscarsClientTest {
 
   @Test
   def testGDMP(): Unit = {
-    val openSearch = OpenSearchClient("https://globalland.vito.be/catalogue",false,"",Collections.singletonList("GDMP"),"cgls_oscars")
+    val openSearch = OpenSearchClient("https://globalland.vito.be/catalogue",false,"",Collections.singletonList("GDMP"),"cgls_oscars", false)
     val collections = openSearch.getCollections("testGDMP")
     assert(collections.length > 10) // by default a page is 100
     val unique = collections.map(_.id).toSet


### PR DESCRIPTION
Adds overloaded constructor to OpenSearchClient.scala so no openeo-geotrellis-extensions code needs updating.