### PR TITLE
Dedup rt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.openeo</groupId>
     <artifactId>openeo-opensearch-client</artifactId>
-    <version>1.2.0_2.12-SNAPSHOT</version>
+    <version>1.3.0_2.12-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/scala/org/openeo/opensearch/OpenSearchResponses.scala
+++ b/src/main/scala/org/openeo/opensearch/OpenSearchResponses.scala
@@ -271,7 +271,7 @@ object OpenSearchResponses {
         ("Removing duplicated feature(s): "
           + toBeRemoved.map(f => "id=" + f.id + "' deduplicationOrderValue='"
           + f.deduplicationOrderValue.getOrElse("") + "'").mkString(", ")
-          + ". Keeping the Latest published one: id=" + selectedElement.id + "' deduplicationOrderValue='"
+          + ". Keeping one with highest deduplicationOrderValue: id=" + selectedElement.id + "' deduplicationOrderValue='"
           + selectedElement.deduplicationOrderValue.getOrElse("") + "'")
       else
         ""

--- a/src/main/scala/org/openeo/opensearch/OpenSearchResponses.scala
+++ b/src/main/scala/org/openeo/opensearch/OpenSearchResponses.scala
@@ -317,26 +317,26 @@ object OpenSearchResponses {
             val geometry = c.downField("geometry").as[Geometry].toOption
             val prefix = "https://www.opengis.net/def/crs/EPSG/0/"
             val crs =
-              if (isUTM && tileId.isEmpty) {
-                //this is ugly, but not having a crs is worse, should be fixed in the catalogs
-                Some(UTM.getZoneCrs(extent.center.x, extent.center.y))
-              } else {
-                if (maybeCRS.isDefined && maybeCRS.get.startsWith(prefix)) {
-                  try {
-                    val epsg = maybeCRS.get.substring(prefix.length)
-                    Some(CRS.fromEpsgCode(epsg.toInt))
+            if(isUTM && tileId.isEmpty){
+              //this is ugly, but not having a crs is worse, should be fixed in the catalogs
+              Some(UTM.getZoneCrs(extent.center.x,extent.center.y))
+            }else {
+              if (maybeCRS.isDefined && maybeCRS.get.startsWith(prefix)) {
+                try {
+                  val epsg = maybeCRS.get.substring(prefix.length)
+                  Some(CRS.fromEpsgCode(epsg.toInt))
 
-                  } catch {
-                    case e: Exception => logger.debug(s"Invalid projection while parsing ${id}, error: ${e.getMessage}")
-                      None
-                  }
-                } else if (tileId.contains("GLOBE")) {
-                  //CGLS specific convention to set tileId to 'GLOBE'
-                  Some(LatLng)
-                } else {
-                  None
+                }catch {
+                  case e: Exception => logger.debug(s"Invalid projection while parsing ${id}, error: ${e.getMessage}")
+                    None
                 }
+              }else if(tileId.contains("GLOBE")){
+                //CGLS specific convention to set tileId to 'GLOBE'
+                Some(LatLng)
+              } else {
+                None
               }
+            }
 
             var res = resolution
             if (res.isEmpty) {

--- a/src/main/scala/org/openeo/opensearch/backends/CGLSOscarsClient.scala
+++ b/src/main/scala/org/openeo/opensearch/backends/CGLSOscarsClient.scala
@@ -9,8 +9,8 @@ import java.time.ZonedDateTime
 import java.util
 import scala.jdk.CollectionConverters.collectionAsScalaIterableConverter
 
-class CGLSOscarsClient(override  val endpoint: URL, val bands: util.List[String]) extends OscarsClient(endpoint,false) {
-
+class CGLSOscarsClient(override val endpoint: URL, val bands: util.List[String]) extends OscarsClient(
+  endpoint, false, deduplicationPropertyJsonPath = "properties.productInformation.productGroupId") {
 
   override def getProducts(collectionId: String, dateRange: Option[(ZonedDateTime, ZonedDateTime)], bbox: ProjectedExtent, attributeValues: collection.Map[String, Any], correlationId: String, processingLevel: String): Seq[OpenSearchResponses.Feature] = {
 

--- a/src/test/scala/org/openeo/opensearch/backends/OscarsClientTest.scala
+++ b/src/test/scala/org/openeo/opensearch/backends/OscarsClientTest.scala
@@ -101,7 +101,7 @@ class OscarsClientTest {
     assert(collections.length > 100) // by default a page is 100
     val unique = collections.map(_.id).toSet
     assertEquals(collections.length, unique.size) // assure no duplicates
-    print(collections)
+    println(collections)
   }
 
   @ParameterizedTest

--- a/src/test/scala/org/openeo/opensearch/backends/OscarsClientTest.scala
+++ b/src/test/scala/org/openeo/opensearch/backends/OscarsClientTest.scala
@@ -40,7 +40,7 @@ class OscarsClientTest {
     assert(collections.length > 10) // by default a page is 100
     val unique = collections.map(_.id).toSet
     assertEquals(collections.length, unique.size) // assure no duplicates
-    print(collections)
+    println(collections)
 
     val features = openSearch.getProducts(
       collectionId = "clms_global_gdmp_300m_v1_10daily_netcdf",
@@ -52,8 +52,7 @@ class OscarsClientTest {
     assertEquals(Some(LatLng),features.head.crs)
     assertEquals(Some(0.00297619047620),features.head.resolution)
     val actual = features.head.links.head.href.toString
-      .replace("-RT5_", "-RT2_")
-    assertEquals("NETCDF:/data/MTDA/Copernicus/Land/global/netcdf/dry_matter_productivity/gdmp_300m_v1_10daily/2018/20180810/c_gls_GDMP300-RT2_201808100000_GLOBE_PROBAV_V1.0.1.nc:GDMP", actual)
+    assertEquals("NETCDF:/data/MTDA/Copernicus/Land/global/netcdf/dry_matter_productivity/gdmp_300m_v1_10daily/2018/20180810/c_gls_GDMP300-RT5_201808100000_GLOBE_PROBAV_V1.0.1.nc:GDMP", actual)
   }
 
   @Test


### PR DESCRIPTION
- Made possible to specify on what property is sorted when deduplicating products. 
The default one was `properties.published`, for CGLSOscarsClient the default is now `properties.productInformation.productGroupId`
```scala
// example how user can specify custom sorting property:
new OscarsClient(
      new URL(url),
      deduplicationPropertyJsonPath = "properties.productInformation.productGroupId",
    )
```
- Removed old pixelValueOffset